### PR TITLE
Remove expchar if running out of space to mimic fortran compilers

### DIFF
--- a/fortranformat/__init__.py
+++ b/fortranformat/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -511,8 +511,10 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
         w = w - nblanks
         nblanks = 0
     # Check value fits in specified width
-    if (nblanks < 0) or (edigits == -1): 
+    if (nblanks < -1) or (edigits == -1): 
         return '*' * w
+    elif (nblanks == -1):
+        expchar = ""
     # See if we have space for a zero before the decimal point
     if (nbefore == 0) and (nblanks > 0):
         leadzero = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,24 @@
+import codecs
 from setuptools import setup, find_packages
+import os
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='fortran_format',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    version=get_version("fortranformat/__init__.py")
 )


### PR DESCRIPTION
I have added a small modification to recreate the behavior of some fortran compilers where if you are only 1 character short, it drops the "E" sign instead of outputting "*".